### PR TITLE
Make work with Node 10.x and add configuration for colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ These two values must be set to interact with Hue bridge. For instructions on ob
 export PHILIPS_HUE_HASH="secrets"
 export PHILIPS_HUE_IP="xxx.xxx.xxx.xxx"
 ```
+You can also configure the hue/sat/bri of the light for both free and meeting mode, the defaults are below.
+
+```
+export PHILIPS_HUE_MEETING_BRI=255
+export PHILIPS_HUE_MEETING_HUE=6144
+export PHILIPS_HUE_MEETING_SAT=255
+export PHILIPS_HUE_FREE_BRI=255
+export PHILIPS_HUE_FREE_HUE=0
+export PHILIPS_HUE_FREE_SAT=0
+```
 
 ## Sample Interaction
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-hue-meeting",
   "description": "Control your Hue lights for meeting mode.",
-  "version": "1.0.2",
+  "version": "1.0.1",
   "author": "Stephen Yeargin <stephen.yeargin@gmail.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts, hue, meeting",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-hue-meeting",
   "description": "Control your Hue lights for meeting mode.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "Stephen Yeargin <stephen.yeargin@gmail.com>",
   "license": "MIT",
   "keywords": "hubot, hubot-scripts, hue, meeting",
@@ -13,7 +13,7 @@
     "url": "https://github.com/stephenyeargin/hubot-hue-meeting/issues"
   },
   "dependencies": {
-    "node-hue-api": "^2.2.0"
+    "node-hue-api": "1.2.1"
   },
   "peerDependencies": {
     "hubot": "2.x"

--- a/src/hue-meeting.coffee
+++ b/src/hue-meeting.coffee
@@ -20,14 +20,19 @@ lightState = hue.lightState
 module.exports = (robot) ->
   base_url = process.env.PHILIPS_HUE_IP
   hash  = process.env.PHILIPS_HUE_HASH
+  meeting_bri = process.env.PHILIPS_HUE_MEETING_BRI or 255
+  meeting_hue = process.env.PHILIPS_HUE_MEETING_HUE or 6144
+  meeting_sat = process.env.PHILIPS_HUE_MEETING_SAT or 255
+  free_bri = process.env.PHILIPS_HUE_FREE_BRI or 255
+  free_hue = process.env.PHILIPS_HUE_FREE_HUE or 0
+  free_sat = process.env.PHILIPS_HUE_FREE_SAT or 0
   api = new HueApi(base_url, hash)
   state = lightState.create()
 
   # Define the various colors and modes
-  meetingColor = lightState.create().on(true).hue(6144).sat(255).bri(255)
-  freeColor = lightState.create().on(true).hue(0).sat(0).bri(255)
-  partyMode = lightState.create().sat(255).effect('colorloop').alert('lselect')
-  backToWork = lightState.create().sat(0).effect('none').alert('none')
+  meetingColor = lightState.create().on(true).hue(meeting_hue).sat(meeting_sat).bri(meeting_bri).alert('select')
+  freeColor = lightState.create().on(true).hue(free_hue).sat(free_sat).bri(free_bri).alert("none").effect('none')
+  partyMode = lightState.create().sat(255).bri(255).effect('colorloop').alert('lselect')
 
   robot.respond /meeting$/i, (res) ->
     res.reply "Setting lights to meeting mode ..."
@@ -50,7 +55,7 @@ module.exports = (robot) ->
         robot.logger.debug status
     else
       res.reply 'Getting back to work now.'
-      api.setGroupLightState '0', backToWork, (err, status) ->
+      api.setGroupLightState '0', freeColor, (err, status) ->
         return handleError res, err if err
         robot.logger.debug status
 

--- a/src/hue-meeting.coffee
+++ b/src/hue-meeting.coffee
@@ -30,7 +30,7 @@ module.exports = (robot) ->
   state = lightState.create()
 
   # Define the various colors and modes
-  meetingColor = lightState.create().on(true).hue(meeting_hue).sat(meeting_sat).bri(meeting_bri).alert('select')
+  meetingColor = lightState.create().on(true).hue(meeting_hue).sat(meeting_sat).bri(meeting_bri).alert('select').effect('none')
   freeColor = lightState.create().on(true).hue(free_hue).sat(free_sat).bri(free_bri).alert("none").effect('none')
   partyMode = lightState.create().sat(255).bri(255).effect('colorloop').alert('lselect')
 


### PR DESCRIPTION
This pr locks the node-hue-api lib to "1.2.1"

Also adds, below info so you can set the default colors

```
export PHILIPS_HUE_MEETING_BRI=255
export PHILIPS_HUE_MEETING_HUE=6144
export PHILIPS_HUE_MEETING_SAT=255
export PHILIPS_HUE_FREE_BRI=255
export PHILIPS_HUE_FREE_HUE=0
export PHILIPS_HUE_FREE_SAT=0
```
